### PR TITLE
feat(k3s-ansible): re-add .14 as agent node

### DIFF
--- a/k3s-ansible/host_vars/192.168.0.14.yml
+++ b/k3s-ansible/host_vars/192.168.0.14.yml
@@ -1,0 +1,10 @@
+---
+# Per-node overrides for rpi5-8gb-rpi-256gb (.14)
+#
+# Re-added as agent (worker) — no etcd, no Longhorn storage.
+# When .14 was a server, etcd WAL fsyncs on the 256GB RPi NVMe caused
+# chronic kubelet crashes and Flannel IPAM exhaustion. As an agent,
+# only workload I/O runs on this drive.
+#
+# Longhorn label intentionally omitted — monitor stability for 7 days
+# before considering node.longhorn.io/create-default-disk=true.

--- a/k3s-ansible/inventory.yml
+++ b/k3s-ansible/inventory.yml
@@ -6,6 +6,9 @@ k3s_cluster:
         192.168.0.11:    # rpi5-8gb-crucial-p3-plus-500gb (bootstrap leader)
         192.168.0.12:    # rpi5-8gb-crucial-bx500-500gb
         192.168.0.13:    # rpi5-8gb-samsung-980-500gb
+    agent:
+      hosts:
+        192.168.0.14:    # rpi5-8gb-rpi-256gb (agent — no etcd)
 
   # Required Vars
   vars:
@@ -55,8 +58,12 @@ k3s_cluster:
         - "eviction-soft=memory.available<512Mi"
         - "eviction-soft-grace-period=memory.available=2m"
         - "eviction-hard=memory.available<256Mi"
-    # No agent nodes — all nodes are servers in this 3-node cluster.
-    # agent_config_yaml: |
+    agent_config_yaml: |
+      kubelet-arg:
+        - "kube-reserved=memory=512Mi,cpu=200m"
+        - "eviction-soft=memory.available<512Mi"
+        - "eviction-soft-grace-period=memory.available=2m"
+        - "eviction-hard=memory.available<256Mi"
     #   See https://docs.k3s.io/installation/configuration#configuration-file
     # registries_config_yaml:  |
     #   Containerd can be configured to connect to private registries and use them to pull images as needed by the kubelet.

--- a/traefik/helmchartconfig.yaml
+++ b/traefik/helmchartconfig.yaml
@@ -15,14 +15,3 @@ spec:
       websecure:
         port: 8443
         exposedPort: 443
-    # Avoid .14 — its I/O constraints cause frequent container crashes
-    # and containerd state corruption, leading to CreateContainerError.
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                    - rpi5-8gb-rpi-256gb


### PR DESCRIPTION
## Summary

- Re-introduce 192.168.0.14 (rpi5-8gb-rpi-256gb) as a **worker (agent)** node instead of a server. As an agent, no etcd runs on .14, eliminating the root cause of all prior instability (etcd WAL fsync contention on the 256GB RPi NVMe).
- Restore `agent_config_yaml` with kubelet eviction settings matching server nodes.
- Remove the Traefik `nodeAffinity` that excluded .14 -- this was a workaround for etcd I/O contention, no longer needed.
- Longhorn storage label intentionally omitted from .14 -- monitor stability for 7 days before enabling.

## Test plan

- [x] Verify .14 is reachable via SSH
- [x] Check no stale node object exists in Kubernetes
- [x] Install k3s agent on .14 and verify it joins as Ready (no control-plane role)
- [x] Apply updated traefik/helmchartconfig.yaml
- [x] Verify DaemonSets schedule on .14 (alloy, node-exporter, metallb-speaker, flannel-ipam-cleanup)
- [x] Verify NO Longhorn manager on .14 (excluded by nodeSelector — engine-image/csi-plugin run as infrastructure)
- [x] Verify NO kube-vip on .14 (excluded by nodeAffinity for control-plane)
- [x] Verify etcd still has exactly 3 members (.11, .12, .13)
- [ ] Monitor 7 days for zero pod restarts on .14

🤖 Generated with [Claude Code](https://claude.com/claude-code)