### PR TITLE
fix(nextcloud): add Tailscale FQDN and LB IP to trusted_domains

### DIFF
--- a/nextcloud/values.yaml
+++ b/nextcloud/values.yaml
@@ -10,6 +10,11 @@ image:
 nextcloud:
   # Tailscale MagicDNS hostname -- becomes nextcloud.<tailnet>.ts.net
   host: nextcloud
+  # All domains the app must accept -- short name for in-cluster, FQDN for apps/browsers
+  trustedDomains:
+    - nextcloud
+    - nextcloud.tailbd291c.ts.net
+    - 192.168.0.206
   existingSecret:
     enabled: true
     secretName: nextcloud-credentials


### PR DESCRIPTION
## Summary

- Adds `nextcloud.tailbd291c.ts.net` and `192.168.0.206` to `nextcloud.trustedDomains` in values.yaml
- Fixes "Access through untrusted domain" error when connecting from the NextCloud mobile app or browser via the full Tailscale FQDN

## Test plan

- [x] ArgoCD syncs the change
- [ ] Mobile app connects to `https://nextcloud.tailbd291c.ts.net` without the trusted domain error
- [ ] Browser access works without the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
