### PR TITLE
fix(monitoring): enable Grafana persistent storage

### DIFF
--- a/monitoring/kube-prometheus-stack-values.yaml
+++ b/monitoring/kube-prometheus-stack-values.yaml
@@ -40,6 +40,12 @@ grafana:
   service:
     type: LoadBalancer
     loadBalancerIP: 192.168.0.203
+  persistence:
+    enabled: true
+    storageClassName: longhorn
+    accessModes:
+      - ReadWriteOnce
+    size: 2Gi
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

- Adds a 2Gi Longhorn PVC for Grafana's `/var/lib/grafana` directory
- Prevents service account tokens from being wiped on pod restarts (Grafana's SQLite DB was previously on ephemeral storage)
- Matches the persistence pattern already used by Prometheus and Alertmanager

## Test plan

- [x] ArgoCD syncs `kube-prometheus-stack` cleanly
- [x] Grafana pod has a bound PVC in the `monitoring` namespace
- [ ] Create a new service account token in Grafana, update it in Vaultwarden, reconnect Grafana MCP, and confirm `list_datasources` returns 200 OK
- [ ] Restart the Grafana pod and verify the token still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
