### PR TITLE
fix(metallb): increase speaker liveness probe timeout for ARM/Pi hardware

### DIFF
--- a/metallb/values.yaml
+++ b/metallb/values.yaml
@@ -2,5 +2,15 @@
 # Chart: metallb/metallb
 # Repo: https://metallb.github.io/metallb
 #
-# Chart defaults are sufficient for the homelab.
 # IPAddressPool and L2Advertisement CRs are applied separately after install.
+
+speaker:
+  livenessProbe:
+    enabled: true
+    # Default timeoutSeconds=1 is too tight for ARM/Pi hardware; frr accumulated
+    # 297 restarts before being caught. 5s gives the FRR process time to respond.
+    timeoutSeconds: 5
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 3
+    successThreshold: 1


### PR DESCRIPTION
## Summary
- Increases MetalLB speaker liveness probe `timeoutSeconds` from 1s (chart default) to 5s
- Root cause: `frr` container accumulated 297 restarts (speaker 96) on Raspberry Pi 5 ARM nodes between March 4–April 4 because the default 1s timeout is too tight for FRR process response time under load on ARM hardware
- Also sets `initialDelaySeconds`, `periodSeconds`, and `failureThreshold` explicitly for visibility (values match chart defaults)

## Test plan
- [ ] ArgoCD syncs `metallb` application cleanly after merge
- [ ] MetalLB speaker pods on all 4 nodes show 0 new restarts after rollout
- [ ] L2 advertisement continues working (LoadBalancer IPs remain reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)