### PR TITLE
fix(claude): use logql parameter in cluster-health skill Loki query

### DIFF
--- a/.claude/commands/cluster-health.md
+++ b/.claude/commands/cluster-health.md
@@ -27,7 +27,7 @@ Run a structured cluster health check using MCP tools. Execute each step in orde
 
 ### 6. Recent errors (last 15 minutes)
 - Call `mcp__grafana__query_loki_logs` with:
-  - query: `{namespace=~".+"} | json | level="error"`
+  - logql: `{namespace=~".+"} | json | level="error"`
   - time range: last 15 minutes
 - Summarize error volume by namespace. Show the top 5 most frequent error messages.
 


### PR DESCRIPTION
## Summary
- Fix `/cluster-health` skill step 6 (Recent errors): `mcp__grafana__query_loki_logs` requires the `logql` parameter, not `query`
- The wrong parameter name sent an empty logql string to Loki, returning "parse error: unexpected \$end" on every run

## Test plan
- [ ] Run `/cluster-health` and verify step 6 returns actual log data instead of a parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)