### PR TITLE
feat(open-webui): self-hosted chat UI proxied to Hermes via Tailscale

### DIFF
--- a/argocd/apps/open-webui.yaml
+++ b/argocd/apps/open-webui.yaml
@@ -23,9 +23,20 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: open-webui
+  # The Tailscale operator rewrites hermes-egress.spec.externalName from
+  # "placeholder" to the proxy's in-cluster DNS once it provisions the egress
+  # proxy. Without this, ArgoCD selfHeal would keep reverting it.
+  ignoreDifferences:
+    - group: ""
+      kind: Service
+      name: hermes-egress
+      namespace: open-webui
+      jsonPointers:
+        - /spec/externalName
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - RespectIgnoreDifferences=true

--- a/argocd/apps/open-webui.yaml
+++ b/argocd/apps/open-webui.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: open-webui
+  namespace: argocd
+spec:
+  project: default
+  sources:
+    - repoURL: https://helm.openwebui.com/
+      chart: open-webui
+      targetRevision: '*'
+      helm:
+        valueFiles:
+          - $repo/open-webui/values.yaml
+    - repoURL: https://github.com/benkim0414/homelab.git
+      targetRevision: HEAD
+      ref: repo
+    - repoURL: https://github.com/benkim0414/homelab.git
+      targetRevision: HEAD
+      path: open-webui
+      directory:
+        include: '{namespace.yaml,hermes-egress.yaml,sealed-secret.yaml,tailscale-ingress.yaml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: open-webui
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/open-webui/README.md
+++ b/open-webui/README.md
@@ -39,21 +39,28 @@ Tailnet device (browser)
 
 ### 1. On the Framework Desktop (Hermes side)
 
-Generate a bearer token and capture the Tailscale IP:
+Generate a bearer token and write it into `~/.hermes/.env`:
 
 ```bash
-~/workspace/hermes/setup/apply-hermes-config.sh
+KEY=$(openssl rand -hex 32)
+printf 'API_SERVER_KEY=%s\n' "$KEY" >> ~/.hermes/.env
 ```
 
-Paste the output snippet into `~/.hermes/.env`. **Then add this CORS origin
-to that file** (append comma-separated if `API_SERVER_CORS_ORIGINS` is
-already set):
+(If `API_SERVER_KEY=` already exists in the file, replace the line instead
+of appending.)
+
+Then add this CORS origin to the same file (append comma-separated if
+`API_SERVER_CORS_ORIGINS` is already set):
 
 ```
 API_SERVER_CORS_ORIGINS=https://open-webui.tailbd291c.ts.net
 ```
 
-Restart `hermes-gateway` so the new key + CORS take effect.
+Restart `hermes-gateway` so the new key + CORS take effect:
+
+```bash
+sudo systemctl restart hermes-gateway
+```
 
 ### 2. On this machine — seal the bearer
 
@@ -78,8 +85,13 @@ sync via `argocd app sync open-webui` or the UI if needed.
 
 To rotate the bearer:
 
-1. Re-run `apply-hermes-config.sh` on the Framework, paste the new value,
-   restart `hermes-gateway`.
+1. On the Framework, generate a new key and replace the `API_SERVER_KEY=`
+   line in `~/.hermes/.env`, then restart `hermes-gateway`:
+   ```bash
+   KEY=$(openssl rand -hex 32)
+   sed -i "s|^API_SERVER_KEY=.*|API_SERVER_KEY=$KEY|" ~/.hermes/.env
+   sudo systemctl restart hermes-gateway
+   ```
 2. Re-run the kubeseal command above with the new key, overwrite
    `open-webui/sealed-secret.yaml`, commit.
 3. ArgoCD picks up the new SealedSecret; the controller decrypts and

--- a/open-webui/README.md
+++ b/open-webui/README.md
@@ -1,0 +1,104 @@
+# Open WebUI
+
+Self-hosted chat UI pointed at the Hermes Agent OpenAI-compatible API on the
+Framework Desktop (tailnet name `fd`, port `8642`). Reachable only from the
+tailnet at `https://open-webui.tailbd291c.ts.net` — no LoadBalancer, no
+public ingress, no cloud LLM keys.
+
+## Architecture
+
+```
+Tailnet device (browser)
+        │  https://open-webui.tailbd291c.ts.net  (Tailscale Ingress, auto LE TLS)
+        ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│  K3s cluster                                                           │
+│                                                                        │
+│  open-webui Pod ──► hermes-egress Service (ExternalName)               │
+│                              │                                         │
+│                              │ tailscale.com/tailnet-fqdn annotation   │
+│                              ▼                                         │
+│                    Tailscale operator egress proxy                     │
+└──────────────────────────────┼─────────────────────────────────────────┘
+                               │
+                               ▼ tailnet
+                  Framework Desktop "fd" :8642 (Hermes API)
+```
+
+## Files
+
+| File                      | Purpose                                                       |
+|---------------------------|---------------------------------------------------------------|
+| `namespace.yaml`          | Namespace `open-webui`                                        |
+| `values.yaml`             | Helm values for the upstream `open-webui` chart               |
+| `hermes-egress.yaml`      | ExternalName Service that the Tailscale operator proxies      |
+| `tailscale-ingress.yaml`  | Tailscale Ingress exposing the chart's Service on the tailnet |
+| `sealed-secret.yaml`      | SealedSecret holding the Hermes bearer (`OPENAI_API_KEY`)     |
+
+## Initial setup
+
+### 1. On the Framework Desktop (Hermes side)
+
+Generate a bearer token and capture the Tailscale IP:
+
+```bash
+~/workspace/hermes/setup/apply-hermes-config.sh
+```
+
+Paste the output snippet into `~/.hermes/.env`. **Then add this CORS origin
+to that file** (append comma-separated if `API_SERVER_CORS_ORIGINS` is
+already set):
+
+```
+API_SERVER_CORS_ORIGINS=https://open-webui.tailbd291c.ts.net
+```
+
+Restart `hermes-gateway` so the new key + CORS take effect.
+
+### 2. On this machine — seal the bearer
+
+```bash
+kubectl create secret generic open-webui-credentials -n open-webui \
+  --from-literal=OPENAI_API_KEY='<PASTE_API_SERVER_KEY_FROM_HERMES>' \
+  --dry-run=client -o yaml \
+| kubeseal \
+    --controller-name sealed-secrets-controller \
+    --controller-namespace kube-system \
+    --format yaml > open-webui/sealed-secret.yaml
+```
+
+Commit the resulting `open-webui/sealed-secret.yaml`.
+
+### 3. ArgoCD sync
+
+The `open-webui` Application autosyncs once committed and merged. Force a
+sync via `argocd app sync open-webui` or the UI if needed.
+
+## Rotation
+
+To rotate the bearer:
+
+1. Re-run `apply-hermes-config.sh` on the Framework, paste the new value,
+   restart `hermes-gateway`.
+2. Re-run the kubeseal command above with the new key, overwrite
+   `open-webui/sealed-secret.yaml`, commit.
+3. ArgoCD picks up the new SealedSecret; the controller decrypts and
+   updates the underlying Secret. Restart the open-webui Pod
+   (`kubectl rollout restart statefulset/open-webui -n open-webui`) so it
+   re-reads the env.
+
+## Verify reachability
+
+From any tailnet device:
+
+```bash
+curl https://open-webui.tailbd291c.ts.net/health
+```
+
+From inside the cluster (egress sanity check):
+
+```bash
+kubectl run -n open-webui --rm -it curl --image=curlimages/curl --restart=Never -- \
+  curl -s http://hermes-egress.open-webui.svc.cluster.local:8642/v1/models \
+       -H "Authorization: Bearer $(kubectl get secret -n open-webui open-webui-credentials -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d)"
+```

--- a/open-webui/hermes-egress.yaml
+++ b/open-webui/hermes-egress.yaml
@@ -16,4 +16,3 @@ spec:
   ports:
     - port: 8642
       protocol: TCP
-      targetPort: 8642

--- a/open-webui/hermes-egress.yaml
+++ b/open-webui/hermes-egress.yaml
@@ -1,0 +1,19 @@
+# Tailscale egress proxy to the Framework Desktop (tailnet name "fd").
+# The Tailscale operator watches the tailnet-fqdn annotation, provisions a
+# proxy StatefulSet in the tailscale namespace, and rewrites this Service's
+# externalName to the proxy's in-cluster DNS. Pods reach Hermes via:
+#   http://hermes-egress.open-webui.svc.cluster.local:8642
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-egress
+  namespace: open-webui
+  annotations:
+    tailscale.com/tailnet-fqdn: fd.tailbd291c.ts.net
+spec:
+  type: ExternalName
+  externalName: placeholder
+  ports:
+    - port: 8642
+      protocol: TCP
+      targetPort: 8642

--- a/open-webui/namespace.yaml
+++ b/open-webui/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-webui

--- a/open-webui/sealed-secret.yaml
+++ b/open-webui/sealed-secret.yaml
@@ -1,6 +1,4 @@
-# Placeholder. Generate the real encryptedData with kubeseal — see README.md.
-# Bitnami sealed-secrets-controller is in kube-system; the SealedSecret target
-# Secret lives in this namespace.
+---
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -8,7 +6,7 @@ metadata:
   namespace: open-webui
 spec:
   encryptedData:
-    OPENAI_API_KEY: REPLACE_WITH_KUBESEAL_OUTPUT
+    OPENAI_API_KEY: AgBc9lV/828HWU5qugNhc/DNG0hqRczslg2AQaCH3lnS+ylGl5xdSz5ypUQ++AupxTvpPbkhJdS+NsDex1EnrTdZI8MIssIgaTWqUcYBnCIv4h7S43WXI28P1XM8CZo0RfbdJUcmxQf6KnIR++i9YY0ynymmqWlDAXS48Gi1J0OaQ+6QejN33VULL5Gcd1UIR39SJOqamcmaXG4PLPGU4MnOflNE9QdJMdzrq2PyEEavJPQ7vawY7Kv6I+ww5i2lKMZxHbWoMibedlHe/kZ59NJ0BioTc7cx81FDCnNgmRgU1Hvh2S3K4safYMfNyE8AUbvE5ybe09ov/iUsIqsUdSUiNFRtaqh0jBSCvRfPKoGmnOQo/T7d6Sy3jDULBye5fzN33FwupUQt1WRadolTHvtO5Czqn+mT2lkLQKruxz13n4wEuulR2it/LdFUa2BdLtxDBfjTLhABSp/Fyrleo0GTI26Zlx1Mdj1GEedxLyceWRNzjYA0TM7r59NkiKqfFgq6z+GGxOU+0VmKxDkQqa/QhWz3AflvUy7eRn0er3XkhsdmRQ7huyMGtOM6WLnX2RHQJQT5yC4HyaKThAgBRXQYkB9lNBTXXXHjIRHBJdyvnz3oV08dfEt0otvA7Id1O/Pc0n2KoP9nXXiHKink77hmVnYAlFFPo1uwHMGguoC38+z0sZOUwQZT/Ymi2eTD1gQ=
   template:
     metadata:
       name: open-webui-credentials

--- a/open-webui/sealed-secret.yaml
+++ b/open-webui/sealed-secret.yaml
@@ -1,0 +1,15 @@
+# Placeholder. Generate the real encryptedData with kubeseal — see README.md.
+# Bitnami sealed-secrets-controller is in kube-system; the SealedSecret target
+# Secret lives in this namespace.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: open-webui-credentials
+  namespace: open-webui
+spec:
+  encryptedData:
+    OPENAI_API_KEY: REPLACE_WITH_KUBESEAL_OUTPUT
+  template:
+    metadata:
+      name: open-webui-credentials
+      namespace: open-webui

--- a/open-webui/tailscale-ingress.yaml
+++ b/open-webui/tailscale-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: open-webui-tailscale
+  namespace: open-webui
+spec:
+  defaultBackend:
+    service:
+      name: open-webui
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - open-webui

--- a/open-webui/values.yaml
+++ b/open-webui/values.yaml
@@ -1,0 +1,45 @@
+# Open WebUI Helm values.
+# Chart: open-webui (https://helm.openwebui.com/)
+#
+# Backend: Hermes Agent OpenAI-compatible API on the Framework Desktop,
+# reached via the in-namespace Tailscale egress Service (hermes-egress.yaml).
+
+# Pin the Service/Deployment name so the Tailscale Ingress backend and the
+# default Service from the chart agree.
+fullnameOverride: open-webui
+
+# SQLite backend can't tolerate concurrent writers.
+replicaCount: 1
+
+# All inference goes to Hermes; no in-cluster model runners or extras.
+ollama:
+  enabled: false
+pipelines:
+  enabled: false
+# Single replica means no need for shared session state. Disabling websocket
+# also drops the bundled Redis Deployment. (Streaming works without it.)
+websocket:
+  enabled: false
+
+# OpenAI-compatible upstream. With pipelines disabled, the chart emits a
+# singular OPENAI_API_BASE_URL + OPENAI_API_KEY (sourced from the secret below).
+openaiBaseApiUrl: "http://hermes-egress.open-webui.svc.cluster.local:8642/v1"
+openaiApiKeyExistingSecret: open-webui-credentials
+openaiApiKeyExistingSecretKey: OPENAI_API_KEY
+
+# Persistent home for sessions, uploads, and SQLite DB.
+persistence:
+  enabled: true
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClass: longhorn
+
+# Reach via the separate Tailscale Ingress (tailscale-ingress.yaml), not the
+# chart's built-in ingress.
+ingress:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 80

--- a/open-webui/values.yaml
+++ b/open-webui/values.yaml
@@ -16,8 +16,11 @@ ollama:
   enabled: false
 pipelines:
   enabled: false
-# Single replica means no need for shared session state. Disabling websocket
-# also drops the bundled Redis Deployment. (Streaming works without it.)
+# Single replica means no need for shared session state, so we drop the
+# bundled Redis Deployment by disabling websocket support entirely. Chat
+# response streaming still works (Open WebUI falls back to SSE), but
+# websocket-only features (multi-tab live updates, async-task progress
+# bars) won't.
 websocket:
   enabled: false
 


### PR DESCRIPTION
## Summary

- Adds Open WebUI as a new ArgoCD-managed app, served only on the tailnet at `https://open-webui.tailbd291c.ts.net`.
- All inference proxied to the Hermes Agent OpenAI-compatible API on the Framework Desktop (`fd:8642`) via a Tailscale operator **egress** Service (`hermes-egress` ExternalName + `tailscale.com/tailnet-fqdn` annotation), since the cluster's Tailscale operator only handles ingress today and pods can't reach tailnet hosts otherwise.
- Disables Pipelines, Ollama, and the bundled websocket Redis to keep the deployment to a single SQLite-backed StatefulSet on Longhorn (10Gi). Bearer token sourced from a SealedSecret (placeholder until `kubeseal` is run locally).

## Pre-merge action items

1. **On the Framework**, run `~/workspace/hermes/setup/apply-hermes-config.sh`, paste into `~/.hermes/.env`, and add this CORS origin (append comma-separated if `API_SERVER_CORS_ORIGINS` already has values):
   ```
   API_SERVER_CORS_ORIGINS=https://open-webui.tailbd291c.ts.net
   ```
   Restart `hermes-gateway`.

2. **Locally**, seal the bearer token (the placeholder `REPLACE_WITH_KUBESEAL_OUTPUT` in `open-webui/sealed-secret.yaml` won't decrypt):
   ```bash
   kubectl create secret generic open-webui-credentials -n open-webui \
     --from-literal=OPENAI_API_KEY='<PASTE_API_SERVER_KEY_FROM_HERMES>' \
     --dry-run=client -o yaml \
   | kubeseal \
       --controller-name sealed-secrets-controller \
       --controller-namespace kube-system \
       --format yaml > open-webui/sealed-secret.yaml
   ```
   Commit the result and push to this branch before syncing.

## Test plan

- [x] `helm template open-webui open-webui/open-webui --version 13.3.1 -n open-webui -f open-webui/values.yaml --validate` renders cleanly (verified locally)
- [x] `kubectl apply --dry-run=client -f open-webui/{namespace,hermes-egress,tailscale-ingress}.yaml -f argocd/apps/open-webui.yaml` passes (verified locally)
- [ ] After merge + sealed secret committed: ArgoCD sync goes Synced/Healthy
- [ ] PVC `open-webui` binds on Longhorn
- [ ] Tailscale operator creates the `hermes-egress` proxy and rewrites the Service's `externalName`
- [ ] From a tailnet device, `curl https://open-webui.tailbd291c.ts.net/health` returns 200
- [ ] Open WebUI lists models from `GET /v1/models` and a chat completes end-to-end (confirms egress + CORS + bearer)
