### PR TITLE
feat(forgejo): seal runner registration token

### DIFF
--- a/forgejo-runner/sealed-secret.yaml
+++ b/forgejo-runner/sealed-secret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: forgejo-runner-token
+  namespace: forgejo-runner
+spec:
+  encryptedData:
+    token: AgBnT2CsETsj158TSFa7YoMv2dyrlGXo5TNsCSQYVDH1T6i5WvFFMbS8/J9KvCeAq4TUr4eF/8tc3AMxk5YewCMJJnoOo6k1U47YWAd760/l2l/MWiAQk/5apsEwFygxRtSW8WSNJLE35NBWE4oJQqGnTZAhGt78TEY+5+FlUmVDrxcnT4oyIx9KwptQtYyWzeJRDCKGg8VVsYX0Le/QgRUht0K9h+24KkJwEyJyp5GAQLZos3uqDamBE7esD6goWwFK1mClgVycf5MfC5cRMOMVPiiuj8/DigBjWpCtTTD5H7rmpVHjqYErf+upnSpsLmDIFvxmeLUJgTZAMadL5VR6hpxX1Fg9cf5ghS7c20SwYRPjMYTW5M8ZA43R0eIPD79KYQfvbz2wVRS0+oTewuM0vodjbg6wcdnbiS6bnJuINmHHn4Vb9JLYN4v+0F844g5YNdoIvOzYjVEQe66zFzuULfoXud/TZxGPZ9Q8MJq4X5v3uvck2ZMxtm5GN6Roi+bKeSc23qgZbF3X8VKcrtR8s6EcdwUa4oZs+h4eeQBjOk//ge+NsC5QkvYNcECrxdo3aOVfMZESpSkWOFnbBFv/QSYOhLBZgodHDY7ei1ECTBHBW+jfoc9FWQiSTh1bu/gLtkC3p33SV0FFABZFHKcoa/dgfFEfc5TKLQL1UZgFVr3D8aNRnWhyERt0Ym9sl7TmIvD0kLDGlJPYlp1mPxS1+DtF9/gUMMkT3hBsfMZOHM7zsHdIfZ3c
+  template:
+    metadata:
+      name: forgejo-runner-token
+      namespace: forgejo-runner


### PR DESCRIPTION
## Summary

- Adds `forgejo-runner/sealed-secret.yaml` — the `forgejo-runner-token` SealedSecret containing the registration token generated from the Forgejo UI
- Unblocks the `forgejo-runner` ArgoCD app which is deployed but pending this secret

## Post-merge

ArgoCD will sync the secret within ~30s. The runner pod will register against `http://forgejo-http.forgejo.svc.cluster.local:3000` and appear green under Site Administration → Actions → Runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)