### PR TITLE
fix(immich): correct offsite-backup CronJob schedule comment

### DIFF
--- a/immich/offsite-backup-cronjob.yaml
+++ b/immich/offsite-backup-cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: immich-offsite-backup
     component: offsite-backup
 spec:
-  # Run at 03:00 AEST / 04:00 AEDT (17:00 UTC), after pg_dump at 03:00 UTC (13:00 AEST)
+  # Run at 17:00 AEST / 18:00 AEDT (07:00 UTC), after pg_dump at 13:00 AEST (03:00 UTC)
   schedule: "0 17 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary

- The schedule `0 17 * * *` fires at **17:00 AEST / 07:00 UTC**, not 03:00 AEST / 17:00 UTC as the old comment claimed
- Discovered when investigating why the scheduled backup job was created at 07:00 UTC instead of the expected 17:00 UTC — the cluster interprets cron schedules in local time (AEST)
- No functional change; comment-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)