### PR TITLE
fix(forgejo): acknowledge wrenix runner chart final release

### DIFF
--- a/forgejo-runner/values.yaml
+++ b/forgejo-runner/values.yaml
@@ -1,3 +1,5 @@
+knownLastVersion: true
+
 image:
   repository: code.forgejo.org/forgejo/runner
   tag: "6.5.0"


### PR DESCRIPTION
## Summary

- Adds `knownLastVersion: true` to `forgejo-runner/values.yaml`
- The wrenix forgejo-runner chart blocks Helm rendering with an execution error unless this flag is explicitly set — the maintainer's deprecation signal for their last published release
- Unblocks the `forgejo-runner` ArgoCD app which is currently in `ComparisonError` state

## Root cause

```
Error: execution error at (forgejo-runner/templates/deployment.yaml:2:4):
This is the last version i release (install with setting `knownLastVersion=true`)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)