### PR TITLE
fix(forgejo): strip registry prefix from runner image repository

### DIFF
--- a/forgejo-runner/values.yaml
+++ b/forgejo-runner/values.yaml
@@ -1,7 +1,7 @@
 knownLastVersion: true
 
 image:
-  repository: code.forgejo.org/forgejo/runner
+  repository: forgejo/runner
   tag: "6.5.0"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Fixes `ErrImagePull` on the `forgejo-runner` pod
- The wrenix chart has a default `image.registry: code.forgejo.org` and concatenates it with `image.repository`, producing a doubled path: `code.forgejo.org/code.forgejo.org/forgejo/runner:6.5.0`
- Fix: set `image.repository: forgejo/runner` (without registry prefix) so the chart resolves the correct image `code.forgejo.org/forgejo/runner:6.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)