### PR TITLE
fix(forgejo): set image.registry to codeberg.org for runner

### DIFF
--- a/forgejo-runner/values.yaml
+++ b/forgejo-runner/values.yaml
@@ -1,6 +1,7 @@
 knownLastVersion: true
 
 image:
+  registry: codeberg.org
   repository: forgejo/runner
   tag: "6.5.0"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- The wrenix chart defaults `image.registry` to `code.forgejo.org`
- With `image.repository: forgejo/runner`, this produces `code.forgejo.org/forgejo/runner:6.5.0` — which does not exist (image returns 404)
- The Forgejo runner images are published at `codeberg.org/forgejo/runner`
- Fix: set `image.registry: codeberg.org` explicitly to override the chart default

🤖 Generated with [Claude Code](https://claude.com/claude-code)