### PR TITLE
fix(forgejo): use correct runner image tag 12.9.0

### DIFF
--- a/forgejo-runner/values.yaml
+++ b/forgejo-runner/values.yaml
@@ -1,9 +1,8 @@
 knownLastVersion: true
 
 image:
-  registry: codeberg.org
   repository: forgejo/runner
-  tag: "6.5.0"
+  tag: "12.9.0"
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
## Summary

- The Forgejo runner project renumbered to v12.x (aligning with Forgejo server versioning) — tag `6.5.0` does not exist at `code.forgejo.org`
- The chart's `appVersion` is `12.7.3`; latest release is `v12.9.0`
- Also reverts the `image.registry: codeberg.org` override added in PR #50 — the chart default `code.forgejo.org` is the correct registry
- Pins to `12.9.0` (latest) so Renovate can track future bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)