### PR TITLE
fix(forgejo): set runner container network to host for DinD

### DIFF
--- a/forgejo-runner/values.yaml
+++ b/forgejo-runner/values.yaml
@@ -29,7 +29,7 @@ runner:
         enabled: true
         dir: "/data/cache"
       container:
-        network: bridge
+        network: host
         privileged: false
         force_pull: false
 


### PR DESCRIPTION
## Summary

- Changes `container.network` from `bridge` to `host` in the runner config — this was the intended value from the original plan
- With a DinD sidecar, jobs need host networking to reach the Docker daemon socket
- Also unblocks ArgoCD's sync retry guard (stuck on revision 4aa5d3e after repeated pre-sync Job failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)