### PR TITLE
fix(forgejo-runner): remove pre-creation of empty .runner file

### DIFF
--- a/forgejo-runner/deployment.yaml
+++ b/forgejo-runner/deployment.yaml
@@ -24,10 +24,10 @@ spec:
             - -c
             - |
               mkdir -p /data/cache
-              touch /data/.runner
+              [ -s /data/.runner ] || rm -f /data/.runner
               chown -R 1001:1001 /data
-              chmod 775 /data/.runner /data/cache
-              chmod g+s /data/.runner /data/cache
+              chmod 775 /data /data/cache
+              chmod g+s /data /data/cache
           securityContext:
             runAsUser: 0
           volumeMounts:


### PR DESCRIPTION
## Summary

- `touch /data/.runner` in init-data pre-created an empty file that `forgejo-runner register` parsed as existing runner config, getting EOF before saving the registration response
- init-data now removes the file when empty (`[ -s /data/.runner ] || rm -f /data/.runner`) so register starts fresh; on subsequent restarts a populated file is preserved
- `chmod` targets `/data` and `/data/cache` (the directories) instead of the no-longer pre-created file; SGID on directories makes new files inherit the group correctly

Root cause: `forgejo-runner register` loads the existing `.runner` file to merge state before writing — empty file produces `io.EOF` which bubbles up as `Error: Failed to register runner: failed to save runner config: EOF`. Token is not consumed when this happens (Forgejo returns the same token on `generate-runner-token`).

## Test plan

- [x] ArgoCD `forgejo-runner` app reaches `Synced` / `Healthy`
- [x] `init-register` pod log shows `Runner registered successfully`
- [x] `forgejo-runner` Deployment pod is `Running` 2/2 (runner + dind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
