### PR TITLE
fix(honcho): set dialectic TOOL_CHOICE=auto for Groq compat

### DIFF
--- a/honcho/honcho-config.yaml
+++ b/honcho/honcho-config.yaml
@@ -43,18 +43,27 @@ data:
   DREAM_DEDUCTION_MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
 
   # ── Dialectic levels (all five tiers point at Groq) ─────────────────────────
+  # TOOL_CHOICE=auto on every tier: Groq's OpenAI-compatible endpoint rejects
+  # the upstream default ("any"/"required") with HTTP 400. Upstream PR #630
+  # changed this default but is unreleased; override here until we bump the
+  # image past commit 94ade07.
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  DIALECTIC_LEVELS__minimal__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  DIALECTIC_LEVELS__low__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  DIALECTIC_LEVELS__medium__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__high__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  DIALECTIC_LEVELS__high__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__max__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  DIALECTIC_LEVELS__max__TOOL_CHOICE: auto


### PR DESCRIPTION
## Summary
- Set \`DIALECTIC_LEVELS__*__TOOL_CHOICE: auto\` for all five tiers in \`honcho/honcho-config.yaml\`
- Fixes HTTP 400 from Groq on every dialectic call (default \`any\` rejected by Groq's OpenAI-compat endpoint)
- Pure config override; matches upstream PR [plastic-labs/honcho#630](https://github.com/plastic-labs/honcho/pull/630), which is merged on \`main\` but not yet released (latest tag \`v3.0.6\` is 35 commits behind \`94ade07\`)

## Why now
After completing the Groq+Gemini key rotation (PRs #58 and #59), authentication is healthy: \`Honcho.get_metadata()\` returns 200, peers/sessions read fine. But \`peer.chat(target=...)\` returns 500 with this in the api pod logs:

\`\`\`
openai.BadRequestError: Error code: 400 - {'error': {'message':
"'tool_choice' : value must be a string (auto or none) or an
object like \`{'type': 'function', 'function': {'name': 'my_function'}}\`"}}
\`\`\`

Hermes uses \`dialecticReasoningLevel: low\`; the other four tiers are set defensively in case a peer changes level later.

## Test plan
- [ ] After ArgoCD syncs the configmap, restart the honcho-api deployment so the new env vars are picked up
- [ ] Manually invoke a dialectic chat from hermes (\`peer.chat(target=user.id)\`) and confirm it returns 200 instead of 500
- [ ] Tail honcho-api logs while the chat fires; no more \`tool_choice\` BadRequestError
- [ ] (Out of scope) Once upstream cuts a release containing 94ade07, bump the image SHA and revert these env-var overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)