### PR TITLE
fix(honcho): dialectic 'low' tier on Gemini 2.0 Flash

### DIFF
--- a/honcho/honcho-config.yaml
+++ b/honcho/honcho-config.yaml
@@ -51,9 +51,14 @@ data:
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
   DIALECTIC_LEVELS__minimal__TOOL_CHOICE: auto
-  DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: openai
-  DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
-  DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
+  # 'low' tier (the only one hermes uses) is on Gemini 2.0 Flash, not Groq:
+  # honcho's dialectic system prompt + tool schemas total ~12k input tokens,
+  # which exceeds Groq's free-tier 12k TPM cap on llama-3.3-70b-versatile.
+  # Gemini 2.0 Flash free tier is 1M TPM, plenty of headroom. The
+  # LLM_GEMINI_API_KEY in honcho-secrets is shared with embeddings; Gemini
+  # quota is per-model so they don't compete.
+  DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: gemini
+  DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: gemini-2.0-flash
   DIALECTIC_LEVELS__low__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile


### PR DESCRIPTION
## Summary
- Switch \`DIALECTIC_LEVELS__low__MODEL_CONFIG\` from Groq llama-3.3-70b to Gemini 2.0 Flash
- Other tiers (minimal/medium/high/max) stay on Groq — unused by hermes today
- Reuses the existing \`LLM_GEMINI_API_KEY\` from honcho-secrets (already used by embeddings)

## Why
PR #60 fixed the \`tool_choice\` BadRequest, but the next dialectic call hit a Groq free-tier rate limit:

\`\`\`
413: Request too large for model llama-3.3-70b-versatile ...
TPM: Limit 12000, Requested 12019
\`\`\`

The dialectic system prompt + tool schemas alone are ~12k tokens — 19 over the free-tier cap. Gemini 2.0 Flash free tier is 1M TPM with the same key, ample headroom. Per-model quotas mean the embedding workload (text-embedding-004) and the chat workload don't share a budget.

## Test plan
- [ ] Hard-refresh ArgoCD app honcho, confirm configmap shows \`DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT=gemini\`
- [ ] Rollout-restart honcho-api so envFrom is re-read
- [ ] From hermes venv: \`peer.chat(\"Briefly: who is benkim0414?\", target=user.id)\` returns a string (not 500)
- [ ] No \`APIStatusError\` / \`tool_choice\` / \`Request too large\` in honcho-api logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)