### PR TITLE
fix(honcho): switch dialectic 'low' tier to Groq llama-3.1-8b-instant

### DIFF
--- a/honcho/honcho-config.yaml
+++ b/honcho/honcho-config.yaml
@@ -51,14 +51,17 @@ data:
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile
   DIALECTIC_LEVELS__minimal__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
   DIALECTIC_LEVELS__minimal__TOOL_CHOICE: auto
-  # 'low' tier (the only one hermes uses) is on Gemini 2.0 Flash, not Groq:
+  # 'low' tier (the only one hermes uses) is on Groq llama-3.1-8b-instant:
   # honcho's dialectic system prompt + tool schemas total ~12k input tokens,
   # which exceeds Groq's free-tier 12k TPM cap on llama-3.3-70b-versatile.
-  # Gemini 2.0 Flash free tier is 1M TPM, plenty of headroom. The
-  # LLM_GEMINI_API_KEY in honcho-secrets is shared with embeddings; Gemini
-  # quota is per-model so they don't compete.
-  DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: gemini
-  DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: gemini-2.0-flash
+  # llama-3.1-8b-instant has a 30k TPM free-tier cap on the same Groq key,
+  # giving 2.5x headroom. Gemini 2.0 Flash was tried first but our
+  # LLM_GEMINI_API_KEY belongs to a billing-enabled GCP project, which makes
+  # free-tier quota zero (the key still works for text-embedding-004 because
+  # that uses a separate quota pool).
+  DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: openai
+  DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: llama-3.1-8b-instant
+  DIALECTIC_LEVELS__low__MODEL_CONFIG__OVERRIDES__BASE_URL: https://api.groq.com/openai/v1
   DIALECTIC_LEVELS__low__TOOL_CHOICE: auto
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: openai
   DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: llama-3.3-70b-versatile


### PR DESCRIPTION
## Summary

- Gemini 2.0 Flash returned HTTP 429 RESOURCE_EXHAUSTED with limit:0 — our LLM_GEMINI_API_KEY is on a billing-enabled GCP project, which gets zero free-tier quota
- Switch to llama-3.1-8b-instant on Groq (30k TPM free-tier vs 12k for 70b) — reuses the existing key, gives 2.5x headroom over the ~12k system-prompt baseline

## Test plan

- [ ] After ArgoCD sync + pod rollout, run \`peer.chat()\` from hermes — expect 200 with non-empty response, no \`ClientError\`/\`429\`/\`413\` in honcho-api logs