### PR TITLE
fix(cluster): restore immich and honcho scheduling

### DIFF
--- a/honcho/honcho-config.yaml
+++ b/honcho/honcho-config.yaml
@@ -14,11 +14,12 @@ data:
   # ── Vector store ────────────────────────────────────────────────────────────
   VECTOR_STORE_TYPE: pgvector
   EMBED_MESSAGES: "true"
-  EMBEDDING_VECTOR_DIMENSIONS: "768"
+  EMBEDDING_VECTOR_DIMENSIONS: "1536"
 
   # ── Embeddings: Gemini embedding-2 ──────────────────────────────────────────
   # LLM_GEMINI_API_KEY is injected from honcho-secrets.
-  # Keep output at 768 dimensions to match the existing pgvector schema.
+  # Keep output at 1536 dimensions while pgvector is active; the running image
+  # rejects alternate dimensions until the vector-store migration is complete.
   EMBEDDING_MODEL_CONFIG__TRANSPORT: gemini
   EMBEDDING_MODEL_CONFIG__MODEL: gemini-embedding-2
 

--- a/immich/postgresql.yaml
+++ b/immich/postgresql.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         app: immich-postgres
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: rpi5-8gb-crucial-bx500-500gb
       containers:
         - name: postgres
           image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0


### PR DESCRIPTION
## Summary

Immich can recover from the unreachable `.12` node now that its Postgres StatefulSet is no longer hard-pinned there. Honcho can start again with pgvector because the embedding dimension matches the value enforced by the running image while vector-store migration is incomplete.

## Verification

- `python3 -c 'import yaml,sys; [list(yaml.safe_load_all(open(p))) for p in sys.argv[1:]]; print("yaml ok")' immich/postgresql.yaml honcho/honcho-config.yaml`
- `git diff --check`

Server-side `kubectl apply --dry-run=server` was not run because direct Kubernetes API access from shell is blocked by policy; live cluster reads were performed through the Kubernetes MCP instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
