### PR TITLE
fix(monitoring): set alloy config reloader uid

### DIFF
--- a/monitoring/alloy-values.yaml
+++ b/monitoring/alloy-values.yaml
@@ -9,6 +9,13 @@ controller:
       operator: Exists
       effect: NoSchedule
 
+configReloader:
+  # Use numeric IDs so containerd does not need to resolve the image's named
+  # user from /etc/passwd before starting the sidecar.
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+
 alloy:
   # Startup can still block on discovery and log tail setup on busy nodes, so
   # keep the readiness timeout above the chart default of 1 second.


### PR DESCRIPTION
## Summary
- set Alloy config-reloader sidecar to run with numeric nobody UID/GID
- avoids containerd image user lookup failure on rpi5-8gb-rpi-256gb

## Verification
- python -c 'import yaml,sys; yaml.safe_load(open("monitoring/alloy-values.yaml")); print("yaml ok")'
- git diff --check