### PR TITLE
fix(forgejo): avoid recursive fsGroup on dump job

### DIFF
--- a/forgejo/forgejo-dump-cronjob.yaml
+++ b/forgejo/forgejo-dump-cronjob.yaml
@@ -28,6 +28,10 @@ spec:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
+            # Avoid recursively walking the live Forgejo data volume on every
+            # backup pod mount; kubelet has hit I/O errors while applying
+            # fsGroup to existing SSH data under this Longhorn volume.
+            fsGroupChangePolicy: OnRootMismatch
           containers:
             - name: dump
               image: codeberg.org/forgejo/forgejo:15.0.0


### PR DESCRIPTION
## Summary
- set fsGroupChangePolicy: OnRootMismatch on the Forgejo dump CronJob pod security context
- avoid recursively walking the live Forgejo data PVC on every backup job mount

## Evidence
- Forgejo is degraded because the forgejo-dump CronJob has not completed its last execution successfully
- Kubernetes events show FailedMount from kubelet applyFSGroup on pvc-aa06fcac... at the mounted ssh path with input/output error
- The Longhorn volume itself reports healthy/attached, so this targets the kubelet fsGroup application path for the dump job rather than storage replacement

## Verification
- yq e '.' forgejo/forgejo-dump-cronjob.yaml
- git diff --check

## Follow-up after merge
- let ArgoCD sync the CronJob
- run or wait for a successful Forgejo dump job to clear CronJob health